### PR TITLE
79083 - Fix paywall alignment case on mobile screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kompasid/web-components",
-  "version": "v1.5.24",
+  "version": "v1.5.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kompasid/web-components",
-      "version": "v1.5.24",
+      "version": "v1.5.25",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "2.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kompasid/web-components",
-  "version": "v1.5.24",
+  "version": "v1.5.25",
   "description": "Kompas.id reusable web components",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/src/components/kompas-paywall-body/kompas-paywall-body.tsx
+++ b/src/components/kompas-paywall-body/kompas-paywall-body.tsx
@@ -134,7 +134,7 @@ export class KompasPaywallBody {
   )
 
   private authRegister = (): void => (
-    <div class="flex flex-row text-white py-2.5 space-x-24 self-center">
+    <div class="flex flex-row text-white px-4 py-2.5 space-x-8 md:space-x-24 self-center">
       <div class="flex flex-col text-left text-xs md:text-sm text-white">
         <b>Sudah berlangganan Kompas.id?</b>
         <p>Masuk untuk lanjut membaca.</p>


### PR DESCRIPTION
* Add padding for auth button
* Set the horizontal space of auth button differently between the small and medium screens & larger.

Very small screen:
![very small screen](https://github.com/pt-kompas-media-nusantara/kompas-web-components/assets/85550554/cd69dabd-76a9-44a1-961d-6e4e6a28526c)

Small screen:
![small screen](https://github.com/pt-kompas-media-nusantara/kompas-web-components/assets/85550554/8706cb71-b9ef-45e2-a611-ff1db2dc6762)

Medium screen:
![medium screen](https://github.com/pt-kompas-media-nusantara/kompas-web-components/assets/85550554/671833cf-e8d0-4395-a2a3-187278cb276e)